### PR TITLE
(fix/Catalogue) - Fixes the Logo sizes to be always a square.

### DIFF
--- a/src/app/repo/repo.component.scss
+++ b/src/app/repo/repo.component.scss
@@ -1,3 +1,4 @@
 .logo-small {
   height: 80px;
+  width: 80px;
 }


### PR DESCRIPTION
Catalogue
![image](https://github.com/user-attachments/assets/4db5c9a4-8de3-4789-8683-1d9d6f55697d)

Catalogue selected page
![image](https://github.com/user-attachments/assets/969c5639-7ed2-4ee3-adde-8d16a6ff46e4)

will be liked this: 

![image](https://github.com/user-attachments/assets/8a2e1262-c84e-45d5-946c-faec9f39b172)
