### PR TITLE
Added faSync Icon to "Last Update"

### DIFF
--- a/src/app/repo-details/repo-details.component.html
+++ b/src/app/repo-details/repo-details.component.html
@@ -55,7 +55,7 @@
             <fa-icon [icon]="faClock"></fa-icon> Created: <span class="float-right">{{ data.repo.created_at | amTimeAgo }}</span>
           </li>
           <li>
-            <fa-icon [icon]="faClock"></fa-icon> Last update: <span class="float-right">{{ data.repo.pushed_at | amTimeAgo }}</span>
+            <fa-icon [icon]="faSync"></fa-icon> Last update: <span class="float-right">{{ data.repo.pushed_at | amTimeAgo }}</span>
           </li>
           <li *ngIf="data.repo?.license">
             <fa-icon [icon]="faBalanceScale"></fa-icon> License: <span class="float-right">{{ data.repo.license.spdx_id }}</span>

--- a/src/app/repo-details/repo-details.component.ts
+++ b/src/app/repo-details/repo-details.component.ts
@@ -11,6 +11,7 @@ import {
   faGlobe,
   faStar,
   faUserCircle,
+  faSync,
 } from '@fortawesome/free-solid-svg-icons';
 import { Observable } from 'rxjs';
 import { pluck, tap } from 'rxjs/operators';
@@ -40,6 +41,7 @@ export class RepoDetailsComponent {
   readonly faCodeBranch = faCodeBranch;
   readonly faClock = faClock;
   readonly faBalanceScale = faBalanceScale;
+  readonly faSync = faSync;
 
   data$: Observable<RepoDetailsData>;
 }


### PR DESCRIPTION
Since we are using `Font Awesome 5` the refresh / rotating Icon is `faSync`

PR Change: 
![image](https://github.com/user-attachments/assets/7316b3e8-df67-4a01-a6e3-3c82e7f7435b)

Current in AC:
![image](https://github.com/user-attachments/assets/34eb9087-8c77-45f6-8bdc-d59fe996db7c)
